### PR TITLE
Fix VTT text merge edge case

### DIFF
--- a/api/core/workflow/nodes/document_extractor/node.py
+++ b/api/core/workflow/nodes/document_extractor/node.py
@@ -597,8 +597,11 @@ def _extract_text_from_vtt(vtt_bytes: bytes) -> str:
 
         for i in range(1, len(raw_results)):
             spk, txt = raw_results[i]
-            if spk == None:
-                merged_results.append((None, current_text))
+            if spk is None:
+                # finalize previous speaker's segment and start a new one with
+                # unknown speaker
+                merged_results.append((current_speaker, current_text))
+                current_speaker, current_text = None, txt
                 continue
 
             if spk == current_speaker:

--- a/api/tests/unit_tests/core/workflow/nodes/test_vtt_extractor.py
+++ b/api/tests/unit_tests/core/workflow/nodes/test_vtt_extractor.py
@@ -1,0 +1,36 @@
+import ast
+import pathlib
+
+import chardet
+import webvtt
+
+SRC_PATH = pathlib.Path(__file__).resolve().parents[5] / "core/workflow/nodes/document_extractor/node.py"
+source = SRC_PATH.read_text()
+module_ast = ast.parse(source)
+func_map = {node.name: node for node in module_ast.body if isinstance(node, ast.FunctionDef)}
+
+
+def load_function(name):
+    ns = {"webvtt": webvtt, "chardet": chardet, "TextExtractionError": Exception}
+    exec(ast.unparse(func_map["_extract_text_from_plain_text"]), ns)  # noqa: S102
+    exec(ast.unparse(func_map[name]), ns)  # noqa: S102
+    return ns[name]
+
+
+def test_extract_text_from_vtt_handles_none_speaker():
+    extract = load_function("_extract_text_from_vtt")
+    vtt_content = (
+        b"WEBVTT\n\n"
+        b"00:00:01.000 --> 00:00:02.000\n"
+        b"<v Speaker 1> Hello\n\n"
+        b"00:00:02.500 --> 00:00:03.000\n"
+        b"<v> um\n\n"
+        b"00:00:03.500 --> 00:00:04.000\n"
+        b"<v Speaker 1> world\n"
+    )
+    result = extract(vtt_content)
+    assert result.splitlines() == [
+        'Speaker 1 " Hello"',
+        ' " um"',
+        'Speaker 1 " world"',
+    ]


### PR DESCRIPTION
## Summary
- fix incorrect speaker merge logic when processing VTT files
- test VTT extraction when an utterance has no speaker
- reformat test to satisfy lint rules

## Testing
- `ruff check ../api/tests/unit_tests/core/workflow/nodes/test_vtt_extractor.py`
- `ruff format ../api/tests/unit_tests/core/workflow/nodes/test_vtt_extractor.py --check`
- `pytest ../api/tests/unit_tests/core/workflow/nodes/test_vtt_extractor.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68883ae085d8833288be5bf165bb79cb